### PR TITLE
fix BigCommerce spelling

### DIFF
--- a/src/components/forms/MerchantForm.js
+++ b/src/components/forms/MerchantForm.js
@@ -58,7 +58,7 @@ const MerchantForm = () =>
         <label htmlFor="platform">Preferred Platform</label>
         <select className="input"  name="platform" id="platform">
           <option value="none">I don't know</option>
-          <option value="big_commerce">Big Commerce</option>
+          <option value="big_commerce">BigCommerce</option>
           <option value="magento">Magento</option>
           <option value="shopify">Shopify</option>
           <option value="other">Other</option>


### PR DESCRIPTION
Pinging @amacgregor with 2 questions:

1. Should I also modify the value `big_commerce` --> `bigcommerce`?
2. Should we use Prettier and create a `.prettierrc`?