### PR TITLE
rename og image

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -43,13 +43,13 @@ const TemplateWrapper = ({ children }) => {
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content={title} />
         <meta name="twitter:description" content={description} />
-        <meta name="twitter:image" content={`${url}/img/og-image.jpg`} />
+        <meta name="twitter:image" content={`${url}/img/ogimage.jpg`} />
 
         <meta property="og:type" content="business.business" />
         <meta property="og:title" content={title} />
         <meta property="og:description" content={description} />
         <meta property="og:url" content={url} />
-        <meta property="og:image" content={`${url}/img/og-image.jpg`} />
+        <meta property="og:image" content={`${url}/img/ogimage.jpg`} />
       </Helmet>
       <Navbar />
       <div>{children}</div>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

I'm renaming the OG Image file name so sharing on LinkedIn shows no image (until it caches the new one) instead of showing the fake coffee company image. If we're pushing out press releases and people start sharing the link, I'd rather show nothing than advertise a different company that doesn't exist.

**Does this PR introduce a breaking change?**

Nada.

**What needs to be documented once your changes are merged?**

Hopefully this will be the last of this issue.
