### PR TITLE
feat: change /merchants to /businesses and setup redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,6 @@
 [build.environment]
   YARN_VERSION = "1.9.4"
   YARN_FLAGS = "--no-ignore-optional"
+[[redirects]]
+  from = "/merchants"
+  to = "/businesses"

--- a/src/pages/businesses.js
+++ b/src/pages/businesses.js
@@ -50,7 +50,7 @@ const financial_options = [
   { value: 'My business will not survive the pandemic', label: 'My business will not survive the pandemic'},
 ]
 
-export default function Merchants() {
+export default function Businesses() {
   return (
     <Layout>
       <div className="py-16 bg-gray-100 sm:py-20 md:py-28">


### PR DESCRIPTION
Redirect `/merchants` route to `/businesses`

Must use the Netlify deployment preview to test it because it won't work locally until the links are updated to the new route.